### PR TITLE
Improvements to extends query parts

### DIFF
--- a/src/Strategies/SQL/MySQL/QueryParts.php
+++ b/src/Strategies/SQL/MySQL/QueryParts.php
@@ -388,6 +388,118 @@ class QueryParts
     }
 
     /**
+     * @param bool $foundRows
+     * @return QueryParts
+     */
+    public function setFoundRows(bool $foundRows): QueryParts
+    {
+        $this->foundRows = $foundRows;
+        return $this;
+    }
+
+    /**
+     * @param string[] $fields
+     * @return QueryParts
+     */
+    public function setFields(array $fields): QueryParts
+    {
+        $this->fields = $fields;
+        return $this;
+    }
+
+    /**
+     * @param string[] $groupBys
+     * @return QueryParts
+     */
+    public function setGroupBys(array $groupBys): QueryParts
+    {
+        $this->groupBys = $groupBys;
+        return $this;
+    }
+
+    /**
+     * @param string[] $orderBys
+     * @return QueryParts
+     */
+    public function setOrderBys(array $orderBys): QueryParts
+    {
+        $this->orderBys = $orderBys;
+        return $this;
+    }
+
+    /**
+     * @param string $from
+     * @return QueryParts
+     */
+    public function setFrom(string $from): QueryParts
+    {
+        $this->from = $from;
+        return $this;
+    }
+
+    /**
+     * @param int $limit
+     * @return QueryParts
+     */
+    public function setLimit(int $limit): QueryParts
+    {
+        $this->limit = $limit;
+        return $this;
+    }
+
+    /**
+     * @param int $offset
+     * @return QueryParts
+     */
+    public function setOffset(int $offset): QueryParts
+    {
+        $this->offset = $offset;
+        return $this;
+    }
+
+    /**
+     * @param string[] $joins
+     * @return QueryParts
+     */
+    public function setJoins(array $joins): QueryParts
+    {
+        $this->joins = $joins;
+        return $this;
+    }
+
+    /**
+     * @param string[] $where
+     * @return QueryParts
+     */
+    public function setWhere(array $where): QueryParts
+    {
+        $this->where = $where;
+        return $this;
+    }
+
+    /**
+     * @param array $params
+     * @return QueryParts
+     */
+    public function setParams(array $params): QueryParts
+    {
+        $this->params = $params;
+        return $this;
+    }
+
+    /**
+     * @param QueryRelations $relations
+     * @return QueryParts
+     */
+    public function setRelations(QueryRelations $relations): QueryParts
+    {
+        $this->relations = $relations;
+        return $this;
+    }
+
+
+
+    /**
      * @param array $params
      * @return QueryParts
      */

--- a/src/Strategies/SQL/MySQL/QueryToSQL.php
+++ b/src/Strategies/SQL/MySQL/QueryToSQL.php
@@ -31,7 +31,7 @@ class QueryToSQL implements IStrategyToSQL
     /**
      * @return IQuery
      */
-    public function getQuery(): IQuery
+    public function getQuery(): ?IQuery
     {
         return $this->query;
     }
@@ -39,10 +39,22 @@ class QueryToSQL implements IStrategyToSQL
     /**
      * @return QueryParts
      */
-    public function getQueryParts(): QueryParts
+    public function getQueryParts(): ?QueryParts
     {
         return $this->queryParts;
     }
+
+    /**
+     * @param QueryParts $queryParts
+     * @return QueryToSQL
+     */
+    public function setQueryParts(QueryParts $queryParts): QueryToSQL
+    {
+        $this->queryParts = $queryParts;
+        return $this;
+    }
+
+
 
     /**
      * @param $reference
@@ -57,7 +69,10 @@ class QueryToSQL implements IStrategyToSQL
 
         /** @var IQuery $reference */
         $this->query = $reference;
-        $this->queryParts = new QueryParts($reference);
+        if(is_null($this->queryParts)){
+            $this->queryParts = new QueryParts($reference);
+        }
+
 
         $sql = new Sql();
         $sql->sentence = $this->getSQLSentence();

--- a/src/Strategies/SQL/MySQL/QueryToSQL.php
+++ b/src/Strategies/SQL/MySQL/QueryToSQL.php
@@ -31,7 +31,7 @@ class QueryToSQL implements IStrategyToSQL
     /**
      * @return IQuery
      */
-    public function getQuery(): ?IQuery
+    public function getQuery(): IQuery
     {
         return $this->query;
     }
@@ -39,22 +39,10 @@ class QueryToSQL implements IStrategyToSQL
     /**
      * @return QueryParts
      */
-    public function getQueryParts(): ?QueryParts
+    public function getQueryParts(): QueryParts
     {
         return $this->queryParts;
     }
-
-    /**
-     * @param QueryParts $queryParts
-     * @return QueryToSQL
-     */
-    public function setQueryParts(QueryParts $queryParts): QueryToSQL
-    {
-        $this->queryParts = $queryParts;
-        return $this;
-    }
-
-
 
     /**
      * @param $reference
@@ -69,10 +57,7 @@ class QueryToSQL implements IStrategyToSQL
 
         /** @var IQuery $reference */
         $this->query = $reference;
-        if(is_null($this->queryParts)){
-            $this->queryParts = new QueryParts($reference);
-        }
-
+        $this->queryParts = new QueryParts($reference);
 
         $sql = new Sql();
         $sql->sentence = $this->getSQLSentence();


### PR DESCRIPTION
Se hicieron unas menjoras en las clases de manera que se puedan extender para alterar su comportamiento.

En QueryParts.php el gran problema es que los métodos son protegidos (evidencia la posibilidad de extenderlo), pero las propiedades con las que trabajan no son accesibles para los sets, eso convertia en imposible de extender la clase.

En QueryToSql.php lo que se agrego es la manera de quer se pueda setear otro QueryParts en caso de que se decida extender el original para un comportamiento diferente sin tener que sobrescribir toda la clase. 